### PR TITLE
Alignment and rounding of DemoView's items

### DIFF
--- a/SwiftUIJitterBug/AppDelegate.swift
+++ b/SwiftUIJitterBug/AppDelegate.swift
@@ -10,12 +10,12 @@ import SwiftUI
 
 @main
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
-    var view : DemoView!
+//    var view : DemoView!
     var window : NSWindow!
     var appState = AppState()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        self.view = DemoView(appState: self.appState)
+        let view = DemoView(appState: appState)
         
         self.window = NSWindow(
             contentRect: NSRect(),
@@ -24,12 +24,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             defer: false
         )
         
-        let hostingView = HostingView(rootView: self.view)
-        hostingView.wantsLayer = true
-        hostingView.layer?.backgroundColor = NSColor.red.cgColor
-
+        let hostingController = HostingViewController(rootView: view)
+        hostingController.sizingOptions = .preferredContentSize
+        hostingController.view.wantsLayer = true
+        hostingController.view.layer?.backgroundColor = NSColor.red.cgColor
+        
         self.window.backgroundColor = .blue
-        self.window.contentView = hostingView
+        self.window.contentViewController = hostingController
         self.window.delegate = self
         
         self.setWindowPosition()

--- a/SwiftUIJitterBug/DemoView.swift
+++ b/SwiftUIJitterBug/DemoView.swift
@@ -11,7 +11,7 @@ struct DemoView : View {
     @ObservedObject var appState : AppState
 
     var body : some View {
-        let size = self.appState.iconSize
+        let size = self.appState.iconSize.rounded()
 
         return VStack(spacing: 0) {
             ForEach(appState.items) { item in
@@ -21,7 +21,8 @@ struct DemoView : View {
                     .padding(15)
                     .frame(
                         width: size,
-                        height: size
+                        height: size,
+                        alignment: .topLeading
                     )
                     .background(.green)
             }

--- a/SwiftUIJitterBug/HostingView.swift
+++ b/SwiftUIJitterBug/HostingView.swift
@@ -27,3 +27,23 @@ class HostingView : NSHostingView<DemoView> {
     }
 }
 
+class HostingViewController: NSHostingController<DemoView> {
+    
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        
+        let viewSize = self.rootView.appState.viewSize
+
+        if viewSize.width != 0 && self.view.frame.size != viewSize {
+            self.rootView.appState.sizeDelta =
+                CGSize(
+                    width: self.view.frame.size.width - viewSize.width,
+                    height: self.view.frame.size.height - viewSize.height
+                )
+        }
+        else {
+            self.rootView.appState.sizeDelta = .zero
+        }
+    }
+}
+


### PR DESCRIPTION
The [.frame()](https://developer.apple.com/documentation/swiftui/view/frame(width:height:alignment:)) modifier defaults to center alignment. When views have different sizes because the GeometryReader body hasn't been run yet, they get draw inset or clipped instead of pushed to an edge with non-center alignments.

In regards to the metrics of the demo, rounding has the best effect on Size Discrepancy. 

I've had rounding help in a few personal situations with GeometryReaders. If you're storing frames/sizes/etc, I've had best results when storing the precise value for SwiftUI's diffing (like you're already doing). With more complicated layouts with multiple children, storing a rounded value has helped reduce body calls but a few times it has hidden some. In your case however, things are simpler and rounding the frame modifier values helps (in my visual testing, M2 MacBook Air)